### PR TITLE
Add default templates for issues and PRs

### DIFF
--- a/ISSUE_TEMPLATE/01_bug_report.md
+++ b/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,0 +1,26 @@
+---
+name: ":bug: Bug report"
+about: Tell us about a problem you are experiencing
+---
+
+<!--
+1. Describe the issue you are having and what you expected to happen.
+-->
+
+<!--
+2. Describe the steps to reproduce, including any log snippets and stack traces that will help diagnose.
+-->
+
+<!--
+3. Describe your environment, including
+   - Version
+   - Environment
+     - For ManageIQ: e.g. VMware appliance, EC2 appliance, Monolithic container, Kubernetes operator, etc
+     - For gems: e.g. `gem env`, `bundle env`, `ruby -v`, etc
+-->
+
+<!--
+4. Update the following if there are additional labels, reviewers, or assignees.
+   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
+-->
+@miq-bot add-label bug

--- a/ISSUE_TEMPLATE/02_feature_request.md
+++ b/ISSUE_TEMPLATE/02_feature_request.md
@@ -1,0 +1,14 @@
+---
+name: ":bulb: Enhancement request"
+about: Suggest an idea for this project
+---
+
+<!--
+1. Describe the enhancement and why you think it is needed.
+-->
+
+<!--
+2. Update the following if there are additional labels, reviewers, or assignees.
+   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
+-->
+@miq-bot add-label enhancement

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+- name: ":question: Question / Support"
+  url: https://github.com/orgs/ManageIQ/discussions
+  about: Please ask and answer questions here.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+1. Describe what this Pull Request does and why you think it is needed.
+   If this PR includes UI or CLI changes, please include Before/After screenshots
+   If this PR includes performance changes, please include Before/After metrics showing improvement.
+-->
+
+<!--
+2. If this fixes an existing issue, please specify in `Fixes #<id>` format
+   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
+-->
+
+<!--
+3. Tell @miq-bot to label this PR with an appropriate scope label (bug, enhancement, etc), and any additional reviewers or assignees.
+   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
+   e.g. `@miq-bot add-label bug`, `@miq-bot add-reviewer @name`
+-->


### PR DESCRIPTION
@ManageIQ/core-admins Please review.

My goal is to eventually also remove the bespoke Issue and PR templates, and ideally only have this consistent list, except where we need to override it.

I tried really hard to keep it short and sweet.  As a contributor, I really can't stand walls-of-words, especially they make me break it down into separate "describe the problem/what happened/what did you expect to happen" sections.

As a reviewer I can't stand seeing all the boilerplate, cause it just gets in the way, especially when the author doesn't remove the boilerplate help text.  So I listed them here as actual HTML comments, so if contributors do leave them in, then at least the final result we look at doesn't have all that stuff.

---

TODO: Remove Issue/PR templates from other repos

- [x] https://github.com/ManageIQ/manageiq/pull/22856
  - https://github.com/ManageIQ/manageiq/blob/master/.github/PULL_REQUEST_TEMPLATE.md
- [x] https://github.com/ManageIQ/manageiq-pods/pull/1040
  - https://github.com/ManageIQ/manageiq-pods/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
  - https://github.com/ManageIQ/manageiq-pods/blob/master/.github/ISSUE_TEMPLATE/feature_request.md
  - https://github.com/ManageIQ/manageiq-pods/blob/master/.github/PULL_REQUEST_TEMPLATE.md
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9054
  - https://github.com/ManageIQ/manageiq-ui-classic/blob/master/.github/PULL_REQUEST_TEMPLATE.md
  - https://github.com/ManageIQ/manageiq-ui-service/blob/master/.github/ISSUE_TEMPLATE.md
- [ ] https://github.com/ManageIQ/rbvmomi2/pull/42 (maybe?)
  - https://github.com/ManageIQ/rbvmomi2/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
  - https://github.com/ManageIQ/rbvmomi2/blob/master/.github/ISSUE_TEMPLATE/feature_request.md
  - https://github.com/ManageIQ/rbvmomi2/blob/master/.github/PULL_REQUEST_TEMPLATE.md

