### PR TITLE
Fix update_yarn_lock to use default if not provided

### DIFF
--- a/.github/workflows/update_yarn_lock.yaml
+++ b/.github/workflows/update_yarn_lock.yaml
@@ -9,7 +9,7 @@ on:
         type: string
       node-version:
         description: The node version to use
-        required: true
+        required: false
         type: string
         default: "20"
     secrets:


### PR DESCRIPTION
@gilbertcherrie Please review.  I didn't realize that required: true when a default was present still forces the caller to pass a value.