### PR TITLE
[update_yarn_lock] Drop concurrency

### DIFF
--- a/.github/workflows/update_yarn_lock.yaml
+++ b/.github/workflows/update_yarn_lock.yaml
@@ -9,9 +9,6 @@ on:
     secrets:
       pr_token:
         required: true
-concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
This should be handled by the caller as the needs may differ per repo.

@jrafanie Please review.  This fixes the deadlock in the ui-classic repo.