### PR TITLE
Fix the yarn.lock snapshot error

### DIFF
--- a/.github/workflows/update_yarn_lock.yaml
+++ b/.github/workflows/update_yarn_lock.yaml
@@ -38,6 +38,7 @@ jobs:
       run: |
         if grep -q '"jest"' package.json; then
           echo "Jest test script found, updating snapshots..."
+          yarn install
           yarn jest -u || echo "No tests to update or tests failed"
           git --no-pager diff
         else


### PR DESCRIPTION
Follow-up to #19

This PR fixes the issue occurring when trying to update the snapshot files in the yarn.lock update.